### PR TITLE
Split glibc and JDK installs into distinct scripts

### DIFF
--- a/java/Dockerfile.7
+++ b/java/Dockerfile.7
@@ -3,5 +3,7 @@ MAINTAINER Maxime Petazzoni <max@signalfx.com>
 
 ENV JAVA_VERSION=7 JAVA_UPDATE=80 JAVA_BUILD=15 JAVA_HOME=/opt/jdk7
 ENV PATH=$JAVA_HOME/bin:$PATH
+ADD ./install_glibc /opt/install_glibc
+RUN /opt/install_glibc
 ADD ./install_jdk /opt/install_jdk
 RUN /opt/install_jdk

--- a/java/Dockerfile.8
+++ b/java/Dockerfile.8
@@ -3,5 +3,7 @@ MAINTAINER Maxime Petazzoni <max@signalfx.com>
 
 ENV JAVA_VERSION=8 JAVA_UPDATE=111 JAVA_BUILD=14 JAVA_HOME=/opt/jdk8 JAVA_JCE=unlimited GLIBC_VERSION=2.23-r3
 ENV PATH=$JAVA_HOME/bin:$PATH
+ADD ./install_glibc /opt/install_glibc
+RUN /opt/install_glibc
 ADD ./install_jdk /opt/install_jdk
 RUN /opt/install_jdk

--- a/java/install_glibc
+++ b/java/install_glibc
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+set -x
+
+echo "Install glibc-${GLIBC_VERSION}..."
+apk-install libstdc++
+for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do
+    curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk;
+done
+apk add --allow-untrusted /tmp/*.apk
+rm -v /tmp/*.apk
+( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8)
+/usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
+
+apk del glibc-i18n
+echo "hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4" >> /etc/nsswitch.conf

--- a/java/install_jdk
+++ b/java/install_jdk
@@ -3,18 +3,6 @@
 set -e
 set -x
 
-echo "Install glibc-${GLIBC_VERSION}..."
-apk-install libstdc++
-for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do
-    curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk;
-done
-apk add --allow-untrusted /tmp/*.apk
-rm -v /tmp/*.apk
-( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8)
-echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh
-/usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
-
-
 mkdir -p /opt
 echo "Installing Java JDK ${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD} into ${JAVA_HOME}..."
 curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" \
@@ -22,7 +10,7 @@ curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" \
   | tar -xzf - -C /opt
 ln -s /opt/jdk1.${JAVA_VERSION}.0_${JAVA_UPDATE} ${JAVA_HOME}
 
-if [ "${JAVA_JCE}" == "unlimited" ]; then
+if [ "${JAVA_JCE}" = "unlimited" ]; then
    echo "Installing Unlimited JCE policy";
    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION}/jce_policy-${JAVA_VERSION}.zip;
@@ -65,6 +53,5 @@ rm -rf ${JAVA_HOME}/*src.zip \
        ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
        ${JAVA_HOME}/jre/lib/oblique-fonts
 
-apk del glibc-i18n
-echo "hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4" >> /etc/nsswitch.conf
+echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh
 echo "jdk-${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD} installed $(date)" >> /root/.built


### PR DESCRIPTION
So we can re-use `install_jdk` in another Ubuntu-based image.