### PR TITLE
Add set -e and -x to apk-install

### DIFF
--- a/rootfs/usr/sbin/apk-install
+++ b/rootfs/usr/sbin/apk-install
@@ -1,3 +1,5 @@
 #!/bin/sh
+set -e
+set -x
 apk --update add $@
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
Makes sure failures in `apk add` correctly fail the build of the Docker
image.