### PR TITLE
Upgrade to alpine 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+java/*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (C) 2013-2014 SignalFuse, Inc. All rights reserved.
 # Copyright (C) 2015-2017 SignalFx, Inc. All rights reserved.
 
-FROM alpine:3.4
+FROM alpine:3.7
 MAINTAINER Maxime Petazzoni <max@signalfx.com>
 
 ADD ./rootfs /

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ for more information on how to use Maestro and the guest utils
 
 ![Java](https://raw.githubusercontent.com/signalfx/maestro-base/master/logo/java.png)
 
-The `:alp-3.2` base image does not include a Java runtime. For this, two
-additional images are available: `:alp-3.2-jdk7` and `:alp-3.2-jdk8`
-that offer Oracle Java JDK7 and JDK8, respectively.
+The `:alp-3.7` base image does not include a Java runtime. For this, another 
+additional images are available: `:alp-3.7-jdk8`
+that offers the Oracle Java JDK8.
 
 To use, setup your `Dockerfile` like so:
 
 ```Dockerfile
 # Let's use Java8
-FROM quay.io/signalfuse/maestro-base:alp-3.2-jdk8
+FROM quay.io/signalfuse/maestro-base:alp-3.7-jdk8
 ...
 ```
 
@@ -45,14 +45,17 @@ Instructions on how the Alpine Linux based
 ## Building the base image
 
 ```
-$ docker build -t quay.io/signalfuse/maestro-base:alp-3.2 .
+$ docker build -t quay.io/signalfuse/maestro-base:alp-3.7 .
 ```
 
 ## Building a Java base image
 
+Oracle no longer provides unauthenticated downloads of jdk8 so you first
+must download the jdk linux-x64.tar.gz file into the java/ sub directory.
+You can find downloads [here](http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-java-plat-419418.html)
 ```
 $ JAVA_VERSION=8 docker build \
   -f java/Dockerfile.${JAVA_VERSION} \
-  -t quay.io/signalfuse/maestro-base:alp-3.2-jdk${JAVA_VERSION} \
+  -t quay.io/signalfuse/maestro-base:alp-3.7-jdk${JAVA_VERSION} \
   java/
 ```

--- a/java/Dockerfile.8
+++ b/java/Dockerfile.8
@@ -1,8 +1,9 @@
-FROM quay.io/signalfuse/maestro-base:alp-3.4
+FROM quay.io/signalfuse/maestro-base:alp-3.7
 MAINTAINER Maxime Petazzoni <max@signalfx.com>
 
-ENV JAVA_VERSION=8 JAVA_UPDATE=152 JAVA_BUILD=16 DOWNLOAD_HASH=aa0333dd3019491ca4f6ddbe78cdb6d0 JAVA_HOME=/opt/jdk8 JAVA_JCE=unlimited GLIBC_VERSION=2.23-r3
+ENV JAVA_VERSION=8 JAVA_UPDATE=152 JAVA_BUILD=16 DOWNLOAD_HASH=aa0333dd3019491ca4f6ddbe78cdb6d0 JAVA_HOME=/opt/jdk8 JAVA_JCE=unlimited GLIBC_VERSION=2.26-r0
 ENV PATH=$JAVA_HOME/bin:$PATH
+COPY ./jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz /tmp/java.tar.gz
 ADD ./install_glibc /opt/install_glibc
 RUN /opt/install_glibc
 ADD ./install_jdk /opt/install_jdk

--- a/java/install_glibc
+++ b/java/install_glibc
@@ -10,8 +10,8 @@ for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_
 done
 apk add --allow-untrusted /tmp/*.apk
 rm -v /tmp/*.apk
-( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8)
-/usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
-
+( /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 C.UTF-8 || true ) && \
+  echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
+  /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
 apk del glibc-i18n
 echo "hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4" >> /etc/nsswitch.conf

--- a/java/install_jdk
+++ b/java/install_jdk
@@ -5,9 +5,8 @@ set -x
 
 mkdir -p /opt
 echo "Installing Java JDK ${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD} into ${JAVA_HOME}..."
-curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" \
-    "http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD}/${DOWNLOAD_HASH}/jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz" \
-  | tar -xzf - -C /opt
+tar -C /opt -xzf /tmp/java.tar.gz
+rm -rf /tmp/java.tar.gz
 ln -s /opt/jdk1.${JAVA_VERSION}.0_${JAVA_UPDATE} ${JAVA_HOME}
 
 if [ "${JAVA_JCE}" = "unlimited" ]; then


### PR DESCRIPTION
There was also a change in the way that the jdk builds need
to happen as Oracle has stopped allowing unauthenticated
donwloads of old JDKs.